### PR TITLE
chore: add some gitignore items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
-cache/
-out/
+# Editor temp files
+*~
+
+# macOS Finder attribute files
+.DS_Store
+
 .idea
 *.aux
 *.log

--- a/LUSDChickenBonds/.gitignore
+++ b/LUSDChickenBonds/.gitignore
@@ -1,0 +1,2 @@
+/cache
+/out


### PR DESCRIPTION
Also move the gitignores of Foundry build outputs to the LUSDChickenBonds
subdirectory. This lets files in those directories be automatically ignored
by VS Code in search results when only that subdirectory of the repo is
opened in the editor.

Arguably, VS Code should respect gitignores from higher up the tree, as it
already does in the Explorer pane. However, it currently doesn't do that for
search results, hence this workaround.