### PR TITLE
ci: use an Etherscan API key for mainnet tests

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -39,6 +39,7 @@ jobs:
           forge test
           -vvv
           --match-contract ChickenBondManagerDevTest
+          --no-match-test '(Shift|RedeemDecreasesAcquiredLUSDInCurveByCorrectFraction)'
 
   mainnet-test:
     name: Mainnet tests


### PR DESCRIPTION
Improves call traces by displaying human-readable function names for
contracts verified on Etherscan.