### PR TITLE
test: turn QuickSort from a library into "free functions"

### DIFF
--- a/LUSDChickenBonds/src/test/TestContracts/ChickenBondManagerTest.sol
+++ b/LUSDChickenBonds/src/test/TestContracts/ChickenBondManagerTest.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.10;
 
 import "./BaseTest.sol";
-import "./QuickSort.sol";
+import "./QuickSort.sol" as QuickSort;
 
 contract ChickenBondManagerTest is BaseTest {
     uint256 constant SECONDS_IN_ONE_MONTH = 2592000;
@@ -2723,7 +2723,7 @@ contract ChickenBondManagerTest is BaseTest {
             startTimeDeltas[i] = _params[i].startTimeDelta;
         }
 
-        startTimeDeltas = QuickSort.sort(startTimeDeltas);
+        QuickSort.sort(startTimeDeltas);
 
         for (uint256 i = 0; i < _params.length; ++i) {
             _params[i].startTimeDelta = startTimeDeltas[i];

--- a/LUSDChickenBonds/src/test/TestContracts/QuickSort.sol
+++ b/LUSDChickenBonds/src/test/TestContracts/QuickSort.sol
@@ -1,37 +1,33 @@
 pragma solidity ^0.8.10;
 
 // Implementation of QuickSort in Solidity strictly for testing purposes (e.g. used in Foundry).
-library QuickSort {
-    function _partition(uint[] memory arr, int lo, int hi) internal pure returns (int p) {
-        int i = lo - 1;
-        int j = hi + 1;
+function _partition(uint[] memory arr, int lo, int hi) pure returns (int p) {
+    int i = lo - 1;
+    int j = hi + 1;
 
-        uint pivot = arr[uint((hi + lo) / 2)];
+    uint pivot = arr[uint((hi + lo) / 2)];
 
-        for (;;) {
-            do { ++i; } while (arr[uint(i)] < pivot);
-            do { --j; } while (arr[uint(j)] > pivot);
+    for (;;) {
+        do { ++i; } while (arr[uint(i)] < pivot);
+        do { --j; } while (arr[uint(j)] > pivot);
 
-            if (i >= j) { return j; }
+        if (i >= j) { return j; }
 
-            (arr[uint(i)], arr[uint(j)]) = (arr[uint(j)], arr[uint(i)]);
-        }
+        (arr[uint(i)], arr[uint(j)]) = (arr[uint(j)], arr[uint(i)]);
     }
+}
 
-    function _sort(uint[] memory arr, int lo, int hi) internal pure {
-        if (lo >= 0 && hi >= 0 && lo < hi) {
-            int p = _partition(arr, lo, hi);
+function _sort(uint[] memory arr, int lo, int hi) pure {
+    if (lo >= 0 && hi >= 0 && lo < hi) {
+        int p = _partition(arr, lo, hi);
 
-            _sort(arr, lo, p);
-            _sort(arr, p + 1, hi);
-        }
+        _sort(arr, lo, p);
+        _sort(arr, p + 1, hi);
     }
+}
 
-    function sort(uint[] memory arr) external pure returns (uint[] memory) {
-        if (arr.length > 0) {
-            _sort(arr, 0, int(arr.length - 1));
-        }
-
-        return arr;
+function sort(uint[] memory arr) pure {
+    if (arr.length > 0) {
+        _sort(arr, 0, int(arr.length - 1));
     }
 }


### PR DESCRIPTION
https://docs.soliditylang.org/en/v0.8.13/contracts.html?highlight=immutable#functions

> Functions outside of a contract, also called “free functions”,
> always have implicit internal visibility. Their code is included
> in all contracts that call them, similar to internal library
> functions.

This avoids https://github.com/foundry-rs/foundry/issues/1184.