### PR TITLE
let MockYearnVault inherit IYearnVault

### DIFF
--- a/LUSDChickenBonds/src/ExternalContracts/MockYearnVault.sol
+++ b/LUSDChickenBonds/src/ExternalContracts/MockYearnVault.sol
@@ -1,35 +1,34 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.10;
 
+import "openzeppelin-contracts/contracts/access/Ownable.sol";
+import "openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
+import "../Interfaces/IYearnVault.sol";
 import "../utils/console.sol";
-import "../../lib/openzeppelin-contracts/contracts/access/Ownable.sol";
-import "../../lib/openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
 import "../test/TestContracts/LUSDTokenTester.sol";
 
-
-contract MockYearnVault is ERC20, Ownable {
-    // ISLUSDToken public sLUSDToken;
-    LUSDTokenTester public token;
+contract MockYearnVault is ERC20, Ownable, IYearnVault {
+    address public token;
 
     constructor(string memory name_, string memory symbol_) ERC20(name_, symbol_) {}
 
     function setAddresses(address _tokenAddress) external onlyOwner {
-        token = LUSDTokenTester(_tokenAddress);
+        token = _tokenAddress;
     }
 
     function deposit(uint256 _tokenAmount) external returns (uint256) {
-        uint lpShares = calcTokenToYToken(_tokenAmount);
-        token.transferFrom(msg.sender, address(this), _tokenAmount);
+        uint lpShares = _tokenAmount * 1e18 / pricePerShare();
 
+        LUSDTokenTester(token).transferFrom(msg.sender, address(this), _tokenAmount);
         _mint(msg.sender, lpShares);
-       
+
         return lpShares;
     }
 
-    function withdraw (uint256 _lpShares) external returns (uint256) {
-        uint tokenAmount = calcYTokenToToken(_lpShares);
-        token.transfer(msg.sender, tokenAmount);
+    function withdraw(uint256 _lpShares) external returns (uint256) {
+        uint tokenAmount = _lpShares * pricePerShare() / 1e18;
 
+        LUSDTokenTester(token).transfer(msg.sender, tokenAmount);
         _burn(msg.sender, _lpShares);
 
         return tokenAmount;
@@ -37,26 +36,17 @@ contract MockYearnVault is ERC20, Ownable {
 
     // Mimic yield harvest - this actually belongs to Strategy contract
     function harvest(uint256 _amount) external {
-        token.unprotectedMint(address(this), _amount);
-    }
-
-    function calcTokenToYToken(uint256 _tokenAmount) public view returns (uint256) {
-        if (token.balanceOf(address(this)) == 0 || totalSupply() == 0) {
-            return _tokenAmount;
-        }
-        return _tokenAmount * totalSupply() / token.balanceOf(address(this));
-    }
-
-    function calcYTokenToToken(uint256 _yTokenAmount) public view returns (uint256) {
-        assert(totalSupply() > 0);
-        return _yTokenAmount * token.balanceOf(address(this)) / totalSupply();
+        LUSDTokenTester(token).unprotectedMint(address(this), _amount);
     }
 
     function pricePerShare() public view returns (uint256) {
-        if (totalSupply() == 0) {
-            return 0;
+        uint256 totalSupplyCached = totalSupply();
+
+        if (totalSupplyCached == 0) {
+            return 1e18;
         }
-        return token.balanceOf(address(this)) * 1e18 / totalSupply();
+
+        return LUSDTokenTester(token).balanceOf(address(this)) * 1e18 / totalSupplyCached;
     }
 
     function lastReport() public pure returns (uint256) {
@@ -69,5 +59,13 @@ contract MockYearnVault is ERC20, Ownable {
 
     function availableDepositLimit() public pure returns (uint256) {
         return 20e18;
+    }
+
+    function setDepositLimit(uint256 _limit) external {
+        // nothing
+    }
+
+    function withdrawalQueue(uint256) external returns (address) {
+        revert("MockYearnVault: withdrawalQueue() not implemented");
     }
 }

--- a/LUSDChickenBonds/src/Interfaces/IYearnVault.sol
+++ b/LUSDChickenBonds/src/Interfaces/IYearnVault.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.10;
 
-import "../../lib/openzeppelin-contracts/contracts/interfaces/IERC20.sol";
+import "openzeppelin-contracts/contracts/interfaces/IERC20Metadata.sol";
 
-interface IYearnVault is IERC20 { 
+interface IYearnVault is IERC20Metadata { 
     function deposit(uint256 _tokenAmount) external returns (uint256);
 
     function withdraw(uint256 _tokenAmount) external returns (uint256);
@@ -12,15 +12,11 @@ interface IYearnVault is IERC20 {
 
     function totalDebt() external view returns (uint256);
 
-    function calcTokenToYToken(uint256 _tokenAmount) external pure returns (uint256); 
-
     function token() external view returns (address);
 
     function availableDepositLimit() external view returns (uint256);
 
     function pricePerShare() external view returns (uint256);
-
-    function name() external view returns (string memory);
 
     function setDepositLimit(uint256 limit) external;
 


### PR DESCRIPTION
This is to ensure we don't forget to implement methods we add to IYearnVault in the mocked version.

Also remove functions from IYearnVault (an interface we use in production code, namely ChickenBondManager.sol) that aren't implemented by "real" Yearn Vaults.