### PR TITLE
chore: fixup imports to let Slither run

### DIFF
--- a/LUSDChickenBonds/foundry.toml
+++ b/LUSDChickenBonds/foundry.toml
@@ -2,7 +2,6 @@
 src = 'src'
 out = 'out'
 libs = ['lib']
-remappings = ['ds-test/=lib/ds-test/src/']
 fuzz_runs = 100
 
 # See more config options https://github.com/gakonst/foundry/tree/master/config

--- a/LUSDChickenBonds/src/ChickenBondManager.sol
+++ b/LUSDChickenBonds/src/ChickenBondManager.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.10;
 
-import "../lib/openzeppelin-contracts/contracts/access/Ownable.sol";
-import "../lib/openzeppelin-contracts/contracts/utils/math/Math.sol";
-import "../lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import "openzeppelin-contracts/contracts/access/Ownable.sol";
+import "openzeppelin-contracts/contracts/utils/math/Math.sol";
+import "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 import "./utils/ChickenMath.sol";
 
 import "./Interfaces/IBondNFT.sol";

--- a/LUSDChickenBonds/src/ExternalContracts/MockCurveLiquidityGaugeV4.sol
+++ b/LUSDChickenBonds/src/ExternalContracts/MockCurveLiquidityGaugeV4.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.8.10;
 
-import "openzeppelin-contracts/contracts/interfaces/IERC20.sol";
+import "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 
 
 contract MockCurveLiquidityGaugeV4 {

--- a/LUSDChickenBonds/src/ExternalContracts/MockLUSDToken.sol
+++ b/LUSDChickenBonds/src/ExternalContracts/MockLUSDToken.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.8.10;
 
 import "../utils/console.sol";
-import "../../lib/openzeppelin-contracts/contracts/interfaces/IERC20.sol";
+import "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 
 
 // MockLUSDToken is a "light" version of the mainnet deployed LUSDToken, with only basic functionality for testing.

--- a/LUSDChickenBonds/src/ExternalContracts/MockYearnVault.sol
+++ b/LUSDChickenBonds/src/ExternalContracts/MockYearnVault.sol
@@ -2,8 +2,8 @@
 pragma solidity ^0.8.10;
 
 import "../utils/console.sol";
-import "../../lib/openzeppelin-contracts/contracts/access/Ownable.sol";
-import "../../lib/openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
+import "openzeppelin-contracts/contracts/access/Ownable.sol";
+import "openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
 import "../test/TestContracts/LUSDTokenTester.sol";
 
 

--- a/LUSDChickenBonds/src/Interfaces/ICurvePool.sol
+++ b/LUSDChickenBonds/src/Interfaces/ICurvePool.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.10;
 
-import "../../lib/openzeppelin-contracts/contracts/interfaces/IERC20.sol";
+import "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 
 interface ICurvePool is IERC20 { 
     function add_liquidity(uint256[2] memory _amounts, uint256 _min_mint_amount) external;

--- a/LUSDChickenBonds/src/Interfaces/ILUSDToken.sol
+++ b/LUSDChickenBonds/src/Interfaces/ILUSDToken.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.10;
 
-import "../../lib/openzeppelin-contracts/contracts/interfaces/IERC20.sol";
+import "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 
 interface ILUSDToken is IERC20 { 
     

--- a/LUSDChickenBonds/src/Interfaces/ISLUSDToken.sol
+++ b/LUSDChickenBonds/src/Interfaces/ISLUSDToken.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.10;
 
-import "../../lib/openzeppelin-contracts/contracts/interfaces/IERC20.sol";
+import "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 
 interface ISLUSDToken is IERC20 {
     function mint(address _to, uint256 _sLUSDAmount) external;

--- a/LUSDChickenBonds/src/Interfaces/IYearnVault.sol
+++ b/LUSDChickenBonds/src/Interfaces/IYearnVault.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.10;
 
-import "../../lib/openzeppelin-contracts/contracts/interfaces/IERC20.sol";
+import "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 
 interface IYearnVault is IERC20 { 
     function deposit(uint256 _tokenAmount) external returns (uint256);

--- a/LUSDChickenBonds/src/LUSDSilo.sol
+++ b/LUSDChickenBonds/src/LUSDSilo.sol
@@ -2,7 +2,7 @@ pragma solidity ^0.8.10;
 
 import "./Interfaces/IChickenBondManager.sol";
 import "./Interfaces/ILUSDToken.sol";
-import "../lib/openzeppelin-contracts/contracts/access/Ownable.sol";
+import "openzeppelin-contracts/contracts/access/Ownable.sol";
 
 contract LUSDSilo is Ownable {
     ILUSDToken public lusdToken; 

--- a/LUSDChickenBonds/src/SLUSDToken.sol
+++ b/LUSDChickenBonds/src/SLUSDToken.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.10;
 
-import "../lib/openzeppelin-contracts/contracts/access/Ownable.sol";
-import "../lib/openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
+import "openzeppelin-contracts/contracts/access/Ownable.sol";
+import "openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
 import "./utils/console.sol";
 
 contract SLUSDToken is ERC20, Ownable {

--- a/LUSDChickenBonds/src/test/TestContracts/BaseTest.sol
+++ b/LUSDChickenBonds/src/test/TestContracts/BaseTest.sol
@@ -2,9 +2,9 @@
 pragma solidity ^0.8.10;
 
 import "ds-test/test.sol";
-import {stdCheats} from "../../../lib/forge-std/src/stdlib.sol";
-import "../../../lib/forge-std/src/Vm.sol";
-import "../../../lib/openzeppelin-contracts/contracts/utils/math/Math.sol";
+import {stdCheats} from "forge-std/stdlib.sol";
+import "forge-std/Vm.sol";
+import "openzeppelin-contracts/contracts/utils/math/Math.sol";
 import "./Accounts.sol";
 import "../../SLUSDToken.sol";
 import "../../BondNFT.sol";
@@ -13,7 +13,7 @@ import "./ChickenBondManagerWrap.sol";
 import "../../Interfaces/IYearnVault.sol";
 import "../../Interfaces/ICurvePool.sol";
 import "../../Interfaces/ICurveLiquidityGaugeV4.sol";
-import "../../../lib/openzeppelin-contracts/contracts/interfaces/IERC20.sol";
+import "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 
 
 contract BaseTest is DSTest, stdCheats {

--- a/LUSDChickenBonds/src/test/TestContracts/QuickSort.sol
+++ b/LUSDChickenBonds/src/test/TestContracts/QuickSort.sol
@@ -1,5 +1,9 @@
 pragma solidity ^0.8.10;
 
+// Dummy contract to get Slither to work
+// It expects every build artifact to include "bytecode"
+contract QuickSortIsNotAContract {}
+
 // Implementation of QuickSort in Solidity strictly for testing purposes (e.g. used in Foundry).
 function _partition(uint[] memory arr, int lo, int hi) pure returns (int p) {
     int i = lo - 1;


### PR DESCRIPTION
Also work around Slither blowing up on a file that contains no contract.