### PR TITLE
Calculate LUSD in Curve as "lpShares * virtualPrice"

### DIFF
--- a/LUSDChickenBonds/src/Interfaces/IChickenBondManager.sol
+++ b/LUSDChickenBonds/src/Interfaces/IChickenBondManager.sol
@@ -34,8 +34,7 @@ interface IChickenBondManager {
     function getAcquiredLUSDInSP() external view returns (uint256);
     function getAcquiredLUSDInCurve() external view returns (uint256);
     function getTotalAcquiredLUSD() external view returns (uint256);
-    function getPermanentLUSDInSP() external view returns (uint256);
-    function getPermanentLUSDInCurve() external view returns (uint256);
+    function getPermanentLUSD() external view returns (uint256);
     function getOwnedLUSDInSP() external view returns (uint256);
     function getOwnedLUSDInCurve() external view returns (uint256);
     function calcSystemBackingRatio() external view returns (uint256);

--- a/LUSDChickenBonds/src/test/ChickenBondManagerMainnetMigrationTest.t.sol
+++ b/LUSDChickenBonds/src/test/ChickenBondManagerMainnetMigrationTest.t.sol
@@ -155,8 +155,7 @@ contract ChickenBondManagerMainnetMigrationTest is BaseTest, MainnetTestSetup {
         shiftFractionFromSPToCurve(10);
 
         // Check permament buckets are > 0
-        assertGt(chickenBondManager.getPermanentLUSDInCurve(), 0);
-        assertGt(chickenBondManager.getPermanentLUSDInSP(), 0);
+        assertGt(chickenBondManager.getPermanentLUSD(), 0);
 
         // Yearn activates migration
         vm.startPrank(yearnGovernanceAddress);
@@ -164,14 +163,13 @@ contract ChickenBondManagerMainnetMigrationTest is BaseTest, MainnetTestSetup {
         vm.stopPrank();
 
         // Check permament buckets are 0
-        assertEq(chickenBondManager.getPermanentLUSDInCurve(), 0);
-        assertEq(chickenBondManager.getPermanentLUSDInSP(), 0);
+        assertEq(chickenBondManager.getPermanentLUSD(), 0);
     }
 
 
     // --- Post-migration logic ---
 
-    function testPostMigrationTotalPOLCanBeRedeemedExceptForFinalRedemptionFee() public {
+    function testPostMigrationTotalPOLCanBeRedeemed() public {
         // Create some bonds
         uint256 bondAmount = 100000e18;
         uint A_bondID = createBondForUser(A, bondAmount);
@@ -224,9 +222,6 @@ contract ChickenBondManagerMainnetMigrationTest is BaseTest, MainnetTestSetup {
         chickenBondManager.redeem(bLUSDToken.balanceOf(A), 0);
         vm.stopPrank();
 
-        uint256 acquiredLUSDInCurveBeforeCRedeem = chickenBondManager.getAcquiredLUSDInCurve();
-        uint256 acquiredYTokensBeforeCRedeem = yearnCurveVault.balanceOf(address(chickenBondManager));
-
         // Final bLUSD holder C redeems
         vm.startPrank(C);
         chickenBondManager.redeem(bLUSDToken.balanceOf(C), 0);
@@ -247,8 +242,8 @@ contract ChickenBondManagerMainnetMigrationTest is BaseTest, MainnetTestSetup {
         uint256 acquiredYTokensAfter = yearnCurveVault.balanceOf(address(chickenBondManager));
 
         // Check that C was able to redeem nearly all of the remaining acquired LUSD in Curve
-        assertApproximatelyEqual(acquiredLUSDInCurveAfter, 0, acquiredLUSDInCurveBeforeCRedeem / 1000, "ac. LUSD in curve after full redeem not ~= 0"); // Within 0.1% relative error
-        assertApproximatelyEqual(acquiredYTokensAfter, 0, acquiredYTokensBeforeCRedeem / 1000, "Curve yTokens after full redeem not ~= 0"); // Within 0.1% relative error
+        assertEq(acquiredLUSDInCurveAfter, 0, "ac. LUSD in curve after full redeem not 0");
+        assertEq(acquiredYTokensAfter, 0, "Curve yTokens after full redeem not 0");
 
         // Check only pending LUSD remains in the SP
         pendingLUSDInSP = chickenBondManager.getPendingLUSD();
@@ -256,7 +251,7 @@ contract ChickenBondManagerMainnetMigrationTest is BaseTest, MainnetTestSetup {
         rawBalSP = lusdToken.balanceOf(address(bammSPVault));
         assertEq(rawBalSP, 0, "B.AMM LUSD balance should be zero");
         uint256 lusdInBAMMSPVault = chickenBondManager.getLUSDInBAMMSPVault();
-        assertApproximatelyEqual(pendingLUSDInSP, lusdInBAMMSPVault, lusdInBAMMSPVault / 1e9, "SP bal != pending after full redemption");  // Within 1e-9 relative error
+        assertEq(pendingLUSDInSP, lusdInBAMMSPVault, "SP bal != pending after full redemption");
     }
 
 
@@ -361,8 +356,7 @@ contract ChickenBondManagerMainnetMigrationTest is BaseTest, MainnetTestSetup {
         shiftFractionFromSPToCurve(10);
 
         // Check permanent buckets are  > 0 before migration
-        assertGt(chickenBondManager.getPermanentLUSDInCurve(), 0);
-        assertGt(chickenBondManager.getPermanentLUSDInSP(), 0);
+        assertGt(chickenBondManager.getPermanentLUSD(), 0);
 
         // Yearn activates migration
         vm.startPrank(yearnGovernanceAddress);
@@ -370,16 +364,14 @@ contract ChickenBondManagerMainnetMigrationTest is BaseTest, MainnetTestSetup {
         vm.stopPrank();
 
         // Check permanent buckets are now 0
-        assertEq(chickenBondManager.getPermanentLUSDInCurve(), 0);
-        assertEq(chickenBondManager.getPermanentLUSDInSP(), 0);
+        assertEq(chickenBondManager.getPermanentLUSD(), 0);
 
         vm.warp(block.timestamp + 10 days);
         // C chickens in
         chickenInForUser(C, C_bondID);
 
         // Check permanent buckets are still 0
-        assertEq(chickenBondManager.getPermanentLUSDInCurve(), 0);
-        assertEq(chickenBondManager.getPermanentLUSDInSP(), 0);
+        assertEq(chickenBondManager.getPermanentLUSD(), 0);
     }
 
     // - post migration CI doesnt change SP POL

--- a/LUSDChickenBonds/src/test/TestContracts/BaseTest.sol
+++ b/LUSDChickenBonds/src/test/TestContracts/BaseTest.sol
@@ -213,8 +213,7 @@ contract BaseTest is DSTest, stdCheats {
         console.log(chickenBondManager.getPendingLUSD(), "totalPendingLUSD");
         console.log(chickenBondManager.getAcquiredLUSDInSP(), "Acquired LUSD in SP");
         console.log(chickenBondManager.getAcquiredLUSDInCurve(), "Acquired LUSD in Curve");
-        console.log(chickenBondManager.getPermanentLUSDInSP(), "Permanent LUSD in SP");
-        console.log(chickenBondManager.getPermanentLUSDInCurve(), "Permanent LUSD in Curve");
+        console.log(chickenBondManager.getPermanentLUSD(), "Permanent LUSD");
         console.log(chickenBondManager.getOwnedLUSDInSP(), "Owned LUSD in SP (Ac. + Perm.)");
         console.log(chickenBondManager.getOwnedLUSDInCurve(), "Owned LUSD in Curve (Ac. + Perm.)");
     }

--- a/LUSDChickenBonds/src/test/TestContracts/ChickenBondManagerTest.sol
+++ b/LUSDChickenBonds/src/test/TestContracts/ChickenBondManagerTest.sol
@@ -322,21 +322,18 @@ contract ChickenBondManagerTest is BaseTest {
         chickenBondManager.createBond(0);
     }
 
-    function testCreateBondDoesNotChangePermanentBuckets() public {
+    function testCreateBondDoesNotChangePermanentBucket() public {
         uint256 bondAmount = 10e18;
 
-        uint256 permanentYearnLUSD_1 = chickenBondManager.getPermanentLUSDInSP();
-        uint256 permanentCurveYTokens_1 = chickenBondManager.getPermanentLUSDInCurve();
+        uint256 permanentLUSD_1 = chickenBondManager.getPermanentLUSD();
 
         // A creates bond
         createBondForUser(A, bondAmount);
         uint256 bondNFT_A = bondNFT.totalMinted();
 
-        uint256 permanentYearnLUSD_2 = chickenBondManager.getPermanentLUSDInSP();
-        uint256 permanentCurveYTokens_2 = chickenBondManager.getPermanentLUSDInCurve();
+        uint256 permanentLUSD_2 = chickenBondManager.getPermanentLUSD();
 
-        assertEq(permanentYearnLUSD_2, permanentYearnLUSD_1);
-        assertEq(permanentCurveYTokens_2, permanentCurveYTokens_1);
+        assertEq(permanentLUSD_2, permanentLUSD_1);
 
         // B creates bond
         createBondForUser(B, bondAmount);
@@ -349,22 +346,17 @@ contract ChickenBondManagerTest is BaseTest {
         chickenBondManager.chickenIn(bondNFT_A);
         vm.stopPrank();
 
-        uint256 permanentYearnLUSD_3 = chickenBondManager.getPermanentLUSDInSP();
-        uint256 permanentCurveYTokens_3 = chickenBondManager.getPermanentLUSDInCurve();
+        uint256 permanentLUSD_3 = chickenBondManager.getPermanentLUSD();
         // Check permanent LUSD Bucket is non-zero
-        assertGt(permanentYearnLUSD_3, 0);
-        // Check permanent Curve bucket has not changed
-        assertEq(permanentCurveYTokens_3, permanentCurveYTokens_2);
+        assertGt(permanentLUSD_3, 0);
 
         // C creates bond
         createBondForUser(C, bondAmount);
 
-        uint256 permanentYearnLUSD_4 = chickenBondManager.getPermanentLUSDInSP();
-        uint256 permanentCurveYTokens_4 = chickenBondManager.getPermanentLUSDInCurve();
+        uint256 permanentLUSD_4 = chickenBondManager.getPermanentLUSD();
 
         // Check permanent buckets have not changed from C's new bond
-        assertEq(permanentYearnLUSD_4, permanentYearnLUSD_3);
-        assertEq(permanentCurveYTokens_4, permanentCurveYTokens_3);
+        assertEq(permanentLUSD_4, permanentLUSD_3);
     }
 
     // --- chickenOut tests ---
@@ -574,7 +566,7 @@ contract ChickenBondManagerTest is BaseTest {
         chickenBondManager.chickenOut(B_bondID, 0);
     }
 
-    function testChickenOutDoesNotChangePermanentBuckets() public {
+    function testChickenOutDoesNotChangePermanentBucket() public {
         // A creates bond
         uint256 bondAmount = 10e18;
 
@@ -585,8 +577,7 @@ contract ChickenBondManagerTest is BaseTest {
         vm.warp(block.timestamp + 7 days);
 
         // Get permanent buckets
-        uint256 permanentYearnLUSD_1 = chickenBondManager.getPermanentLUSDInSP();
-        uint256 permanentCurveYTokens_1 = chickenBondManager.getPermanentLUSDInCurve();
+        uint256 permanentLUSD_1 = chickenBondManager.getPermanentLUSD();
 
         // A chickens out
         vm.startPrank(A);
@@ -594,10 +585,8 @@ contract ChickenBondManagerTest is BaseTest {
         vm.stopPrank();
 
         // Check permanent buckets haven't changed
-        uint256 permanentYearnLUSD_2 = chickenBondManager.getPermanentLUSDInSP();
-        uint256 permanentCurveYTokens_2 = chickenBondManager.getPermanentLUSDInCurve();
-        assertEq(permanentYearnLUSD_2, permanentYearnLUSD_1);
-        assertEq(permanentCurveYTokens_2, permanentCurveYTokens_1);
+        uint256 permanentLUSD_2 = chickenBondManager.getPermanentLUSD();
+        assertEq(permanentLUSD_2, permanentLUSD_1);
 
         // B, C create bond
         createBondForUser(B, bondAmount);
@@ -614,12 +603,9 @@ contract ChickenBondManagerTest is BaseTest {
         vm.stopPrank();
 
         // Get permanent buckets, check > 0
-        uint256 permanentYearnLUSD_3 = chickenBondManager.getPermanentLUSDInSP();
-        uint256 permanentCurveYTokens_3 = chickenBondManager.getPermanentLUSDInCurve();
+        uint256 permanentLUSD_3 = chickenBondManager.getPermanentLUSD();
         // Check LUSD permanent bucket has increased
-        assertGt(permanentYearnLUSD_3, 0);
-        // Check Curve permanent bucket still be 0
-        assertEq(permanentCurveYTokens_3, 0);
+        assertGt(permanentLUSD_3, 0);
 
         // C chickens out
         vm.startPrank(C);
@@ -627,10 +613,8 @@ contract ChickenBondManagerTest is BaseTest {
         vm.stopPrank();
 
         // Check permanent bucekt haven't changed
-        uint256 permanentYearnLUSD_4 = chickenBondManager.getPermanentLUSDInSP();
-        uint256 permanentCurveYTokens_4 = chickenBondManager.getPermanentLUSDInCurve();
-        assertEq(permanentYearnLUSD_4, permanentYearnLUSD_3);
-        assertEq(permanentCurveYTokens_4, permanentCurveYTokens_3);
+        uint256 permanentLUSD_4 = chickenBondManager.getPermanentLUSD();
+        assertEq(permanentLUSD_4, permanentLUSD_3);
     }
 
     // --- calcbLUSD Accrual tests ---
@@ -1239,15 +1223,15 @@ contract ChickenBondManagerTest is BaseTest {
         createBondForUser(B, bondAmount);
         uint256 B_bondID = bondNFT.totalMinted();
 
-        uint256 permanentYearnLUSD_1 = chickenBondManager.getPermanentLUSDInSP();
+        uint256 permanentLUSD_1 = chickenBondManager.getPermanentLUSD();
 
         // A chickens in
         vm.startPrank(A);
         chickenBondManager.chickenIn(A_bondID);
         vm.stopPrank();
 
-        uint256 permanentYearnLUSD_2 = chickenBondManager.getPermanentLUSDInSP();
-        assertGt(permanentYearnLUSD_2, permanentYearnLUSD_1);
+        uint256 permanentLUSD_2 = chickenBondManager.getPermanentLUSD();
+        assertGt(permanentLUSD_2, permanentLUSD_1);
 
         // C creates bond
         createBondForUser(C, bondAmount);
@@ -1256,7 +1240,7 @@ contract ChickenBondManagerTest is BaseTest {
         // fast forward time
         vm.warp(block.timestamp + 7 days);
 
-        uint256 permanentYearnLUSD_3 = chickenBondManager.getPermanentLUSDInSP();
+        uint256 permanentLUSD_3 = chickenBondManager.getPermanentLUSD();
 
         // B chickens in
         vm.startPrank(B);
@@ -1264,13 +1248,13 @@ contract ChickenBondManagerTest is BaseTest {
         vm.stopPrank();
 
         // Check permanent LUSD bucket has increased
-        uint256 permanentYearnLUSD_4 = chickenBondManager.getPermanentLUSDInSP();
-        assertGt(permanentYearnLUSD_4, permanentYearnLUSD_3);
+        uint256 permanentLUSD_4 = chickenBondManager.getPermanentLUSD();
+        assertGt(permanentLUSD_4, permanentLUSD_3);
 
         // fast forward time
         vm.warp(block.timestamp + 7 days);
 
-        uint256 permanentYearnLUSD_5 = chickenBondManager.getPermanentLUSDInSP();
+        uint256 permanentLUSD_5 = chickenBondManager.getPermanentLUSD();
 
         // C chickens in
         vm.startPrank(C);
@@ -1278,65 +1262,8 @@ contract ChickenBondManagerTest is BaseTest {
         vm.stopPrank();
 
         // Check permanent LUSD bucket has increased
-        uint256 permanentYearnLUSD_6 = chickenBondManager.getPermanentLUSDInSP();
-        assertGt(permanentYearnLUSD_6, permanentYearnLUSD_5);
-    }
-
-    function testChickenInDoesNotChangePermanentCurveBucket() public {
-        // A, B create bond
-        uint256 bondAmount = 10e18;
-
-        createBondForUser(A, bondAmount);
-        uint256 A_bondID = bondNFT.totalMinted();
-
-        // fast forward time
-        vm.warp(block.timestamp + 7 days);
-
-        createBondForUser(B, bondAmount);
-        uint256 B_bondID = bondNFT.totalMinted();
-
-        uint256 permanentCurveYTokens_1 = chickenBondManager.getPermanentLUSDInCurve();
-
-        // A chickens in
-        vm.startPrank(A);
-        chickenBondManager.chickenIn(A_bondID);
-        vm.stopPrank();
-
-        // Check permanent Curve bucket has not changed
-        uint256 permanentCurveYTokens_2 = chickenBondManager.getPermanentLUSDInCurve();
-        assertEq(permanentCurveYTokens_2, permanentCurveYTokens_1);
-
-        // C creates bond
-        createBondForUser(C, bondAmount);
-        uint256 C_bondID = bondNFT.totalMinted();
-
-        // fast forward time
-        vm.warp(block.timestamp + 7 days);
-
-        uint256 permanentCurveYTokens_3 = chickenBondManager.getPermanentLUSDInCurve();
-
-        // B chickens in
-        vm.startPrank(B);
-        chickenBondManager.chickenIn(B_bondID);
-        vm.stopPrank();
-
-        // Check permanent Curve bucket has not changed
-        uint256 permanentCurveYTokens_4 = chickenBondManager.getPermanentLUSDInCurve();
-        assertEq(permanentCurveYTokens_4, permanentCurveYTokens_3);
-
-        // fast forward time
-        vm.warp(block.timestamp + 7 days);
-
-        uint256 permanentCurveYTokens_5 = chickenBondManager.getPermanentLUSDInCurve();
-
-        // C chickens in
-        vm.startPrank(C);
-        chickenBondManager.chickenIn(C_bondID);
-        vm.stopPrank();
-
-        // Check permanent Curve bucket has not changed
-        uint256 permanentCurveYTokens_6 = chickenBondManager.getPermanentLUSDInCurve();
-        assertEq(permanentCurveYTokens_6, permanentCurveYTokens_5);
+        uint256 permanentLUSD_6 = chickenBondManager.getPermanentLUSD();
+        assertGt(permanentLUSD_6, permanentLUSD_5);
     }
 
     // --- redemption tests ---
@@ -1555,17 +1482,15 @@ contract ChickenBondManagerTest is BaseTest {
     }
 
     function testRedeemDecreasesAcquiredLUSDInSPByCorrectFraction(uint256 redemptionFraction) public {
-        vm.assume(redemptionFraction <= 1e18 && redemptionFraction >= 1e9);
-        // uint256 redemptionFraction = 5e17; // 50%
+        redemptionFraction = coerce(redemptionFraction, 1e9, 1e18);
+
         // 1-r.  Fee goes to permanent
         uint256 expectedFractionRemainingAfterRedemption = 1e18 - redemptionFraction;
-        // Ensure the expected remaining is between 0 and 100%
-        assertTrue(expectedFractionRemainingAfterRedemption > 0 && expectedFractionRemainingAfterRedemption < 1e18);
 
         // A creates bond
         uint256 bondAmount = 10e18;
 
-       createBondForUser(A, bondAmount);
+        createBondForUser(A, bondAmount);
 
         // bootstrap period passes
         vm.warp(block.timestamp + chickenBondManager.BOOTSTRAP_PERIOD_CHICKEN_IN());
@@ -1599,10 +1524,8 @@ contract ChickenBondManagerTest is BaseTest {
 
         // B redeems some bLUSD
         uint256 bLUSDToRedeem = bLUSDBalance * redemptionFraction / 1e18;
-
         assertGt(bLUSDToRedeem, 0);
 
-        assertTrue(bLUSDToRedeem != 0);
         vm.startPrank(B);
 
         assertEq(bLUSDToRedeem, bLUSDToken.totalSupply() * redemptionFraction / 1e18);
@@ -1815,44 +1738,6 @@ contract ChickenBondManagerTest is BaseTest {
 
         // Check that CBM was able to withdraw almost exactly its initial deposit
         assertApproximatelyEqual(_depositAmount, lusdToken.balanceOf(address(chickenBondManager)), 1e3);
-    }
-
-    // --- Curve getter tests ---
-
-    function testCurveCalcWithdrawOneCoinSucceeds(uint256 _LUSD3CRVAmount) public {
-        uint256 totalLPTokens = curvePool.totalSupply();
-        // Total Supply:  92600301889123371838218704
-        // Failing input: 926003018891233718382188
-
-        // Seems to revert at >=1% of totalLPTokens. TODO: Why? Does Curve somehow limit withdrawals?
-
-        assertGt(totalLPTokens, 0);
-
-        vm.assume(_LUSD3CRVAmount <= totalLPTokens / 100 && _LUSD3CRVAmount > 0);
-
-        uint256 withdrawableLUSD = curvePool.calc_withdraw_one_coin(_LUSD3CRVAmount * 100, 0);
-
-        assertGt(withdrawableLUSD, 0);
-
-    }
-
-    function testCurveCalcTokenAmountWithdrawalSucceeds(uint256 _lusdAmount) public {
-        uint256 totalLUSDinCurve = curvePool.balances(0);
-        vm.assume(_lusdAmount < totalLUSDinCurve && _lusdAmount > 1e18);
-
-        bool isDeposit = false;
-        uint256 lpTokensToBurn = curvePool.calc_token_amount([_lusdAmount, 0], isDeposit);
-
-        assertGt(lpTokensToBurn, 0);
-    }
-
-    function testCurveCalcTokenAmountDepositSucceeds(uint256 _lusdAmount) public {
-        vm.assume(_lusdAmount <= 1e27 && _lusdAmount > 1e18);
-
-        bool isDeposit = true;
-        uint256 lpTokensReceived = curvePool.calc_token_amount([_lusdAmount, 0], isDeposit);
-
-        assertGt(lpTokensReceived, 0);
     }
 
     // --- Controller tests ---


### PR DESCRIPTION
Main changes in ChickenBondManager:
- Calculate LUSD in Curve as "lpShares * virtualPrice".
- Eliminate the use of calc_token_amount() when calculating number of LP tokens to withdraw.
- Track permanent LUSD in a single state variable.

Deleted some test cases that are redundant.

Fixes #111 