### PR TITLE
Add support for creating a bond with a permit rather than an approval

### DIFF
--- a/LUSDChickenBonds/src/ChickenBondManager.sol
+++ b/LUSDChickenBonds/src/ChickenBondManager.sol
@@ -261,7 +261,7 @@ contract ChickenBondManager is ChickenMath, IChickenBondManager {
 
     // --- User-facing functions ---
 
-    function createBond(uint256 _lusdAmount) external returns (uint256) {
+    function createBond(uint256 _lusdAmount) public returns (uint256) {
         _requireNonZeroAmount(_lusdAmount);
         _requireMinBond(_lusdAmount);
         _requireMigrationNotActive();
@@ -290,6 +290,18 @@ contract ChickenBondManager is ChickenMath, IChickenBondManager {
         emit BondCreated(msg.sender, bondID, _lusdAmount, bondData.initialHalfDna);
 
         return bondID;
+    }
+
+    function createBondWithPermit(
+        address owner, 
+        uint256 amount, 
+        uint256 deadline, 
+        uint8 v, 
+        bytes32 r, 
+        bytes32 s
+    ) external returns (uint256) {
+        lusdToken.permit(owner, address(this), amount, deadline, v, r, s);
+        return createBond(amount);
     }
 
     function chickenOut(uint256 _bondID, uint256 _minLUSD) external {

--- a/LUSDChickenBonds/src/Interfaces/IChickenBondManager.sol
+++ b/LUSDChickenBonds/src/Interfaces/IChickenBondManager.sol
@@ -24,6 +24,14 @@ interface IChickenBondManager {
     function INDEX_OF_LUSD_TOKEN_IN_CURVE_POOL() external pure returns (int128);
 
     function createBond(uint256 _lusdAmount) external returns (uint256);
+    function createBondWithPermit(
+        address owner, 
+        uint256 amount, 
+        uint256 deadline, 
+        uint8 v, 
+        bytes32 r, 
+        bytes32 s
+    ) external  returns (uint256);
     function chickenOut(uint256 _bondID, uint256 _minLUSD) external;
     function chickenIn(uint256 _bondID) external;
     function redeem(uint256 _bLUSDToRedeem, uint256 _minLUSDFromBAMMSPVault) external returns (uint256, uint256);

--- a/LUSDChickenBonds/src/Interfaces/ILUSDToken.sol
+++ b/LUSDChickenBonds/src/Interfaces/ILUSDToken.sol
@@ -21,4 +21,14 @@ interface ILUSDToken is IERC20 {
     function sendToPool(address _sender,  address poolAddress, uint256 _amount) external;
 
     function returnFromPool(address poolAddress, address user, uint256 _amount ) external;
+
+    function permit(
+        address owner,
+        address spender,
+        uint256 value,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external;
 }

--- a/LUSDChickenBonds/src/test/TestContracts/BaseTest.sol
+++ b/LUSDChickenBonds/src/test/TestContracts/BaseTest.sol
@@ -12,6 +12,7 @@ import "../../Interfaces/IYearnVault.sol";
 import "../../Interfaces/IBAMM.sol";
 import "../../Interfaces/ICurvePool.sol";
 import "../../Interfaces/ICurveLiquidityGaugeV5.sol";
+import "./Interfaces/IERC20Permit.sol";
 import "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 import "./TestUtils.sol";
 
@@ -27,7 +28,7 @@ contract BaseTest is Test {
     BLUSDToken bLUSDToken;
 
     // Integrations
-    IERC20 lusdToken;
+    IERC20Permit lusdToken;
     IERC20 _3crvToken;
     ICurvePool curvePool;
     ICurvePool curveBasePool;

--- a/LUSDChickenBonds/src/test/TestContracts/ChickenBondManagerTest.sol
+++ b/LUSDChickenBonds/src/test/TestContracts/ChickenBondManagerTest.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.10;
 
 import "./BaseTest.sol";
 import "./QuickSort.sol" as QuickSort;
-import "forge-std/console.sol";
 
 contract ChickenBondManagerTest is BaseTest {
     function testSetupSetsBondNFTAddressInCBM() public {
@@ -2386,5 +2385,38 @@ contract ChickenBondManagerTest is BaseTest {
         chickenOutForUser(B, B_bondId);
         openBondsCount = chickenBondManager.getOpenBondCount();
         assertEq(openBondsCount, 0);
+    }
+
+    function testCreateBondWithPermit() public {
+        uint256 bondAmount = 100e18;
+        uint256 activeBondsBefore = chickenBondManager.getOpenBondCount();
+        address owner = accountsList[0];
+        address spender = address(chickenBondManager);
+        uint256 deadline = block.timestamp + 100;
+        uint256 nonce = lusdToken.nonces(owner);
+
+        bytes32 permitStructHash = keccak256(
+            abi.encode(
+                lusdToken.permitTypeHash(),
+                owner,
+                spender,
+                bondAmount,
+                nonce,
+                deadline
+            )
+        );
+
+        bytes32 permitDigest = keccak256(
+            abi.encodePacked("\x19\x01", lusdToken.domainSeparator(), permitStructHash)
+        );
+
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(accounts.accountsPks(0), permitDigest);
+        
+        vm.prank(owner);
+        chickenBondManager.createBondWithPermit(owner, bondAmount, deadline, v, r, s);
+        
+        uint256 activeBondsAfter = chickenBondManager.getOpenBondCount();
+
+        assertEq(activeBondsAfter, activeBondsBefore + 1);
     }
 }

--- a/LUSDChickenBonds/src/test/TestContracts/DevTestSetup.sol
+++ b/LUSDChickenBonds/src/test/TestContracts/DevTestSetup.sol
@@ -22,7 +22,7 @@ contract DevTestSetup is BaseTest {
 
         // Deploy a mock token then assign its interface
         LUSDTokenTester mockLUSDToken = new LUSDTokenTester(ZERO_ADDRESS,ZERO_ADDRESS, ZERO_ADDRESS);
-        lusdToken = IERC20(address(mockLUSDToken));
+        lusdToken = IERC20Permit(address(mockLUSDToken));
 
         (A, B, C, D, yearnGovernanceAddress) = (accountsList[0], accountsList[1], accountsList[2], accountsList[3], accountsList[9]);
 

--- a/LUSDChickenBonds/src/test/TestContracts/Interfaces/IERC20Permit.sol
+++ b/LUSDChickenBonds/src/test/TestContracts/Interfaces/IERC20Permit.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.10;
+
+import "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+
+interface IERC20Permit is IERC20 {
+    function permit(
+        address owner,
+        address spender,
+        uint256 amount,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external;
+    function domainSeparator() external view returns (bytes32);
+    function permitTypeHash() external view returns (bytes32);
+    function nonces(address owner) external view returns (uint256);
+    function name() external view returns (string memory);
+}

--- a/LUSDChickenBonds/src/test/TestContracts/MainnetTestSetup.sol
+++ b/LUSDChickenBonds/src/test/TestContracts/MainnetTestSetup.sol
@@ -42,7 +42,7 @@ contract MainnetTestSetup is BaseTest {
         createAccounts();
 
         // Grab deployed mainnet LUSDToken
-        lusdToken = IERC20(MAINNET_LUSD_TOKEN_ADDRESS);
+        lusdToken = IERC20Permit(MAINNET_LUSD_TOKEN_ADDRESS);
 
         _3crvToken = IERC20(MAINNET_3CRV_TOKEN_ADDRESS);
 


### PR DESCRIPTION
Enables frontends to create a bond with one broadcast transaction using the EIP 2616 approach.