### PR TITLE
feat: emit an event when controller adjusts

### DIFF
--- a/LUSDChickenBonds/src/ChickenBondManager.sol
+++ b/LUSDChickenBonds/src/ChickenBondManager.sol
@@ -195,6 +195,7 @@ contract ChickenBondManager is ChickenMath, IChickenBondManager {
     event BondCancelled(address indexed bonder, uint256 bondId, uint256 principalLusdAmount, uint256 minLusdAmount, uint256 withdrawnLusdAmount, uint128 bondFinalHalfDna);
     event BLUSDRedeemed(address indexed redeemer, uint256 bLusdAmount, uint256 minLusdAmount, uint256 lusdAmount, uint256 yTokens, uint256 redemptionFee);
     event MigrationTriggered(uint256 previousPermanentLUSD);
+    event AccrualParameterUpdated(uint256 accrualParameter);
 
     // --- Constructor ---
 
@@ -892,6 +893,7 @@ contract ChickenBondManager is ChickenMath, IChickenBondManager {
 
             if (updatedAccrualParameter != storedAccrualParameter) {
                 accrualParameter = updatedAccrualParameter;
+                emit AccrualParameterUpdated(updatedAccrualParameter);
             }
         }
 

--- a/LUSDChickenBonds/src/test/TestContracts/ChickenBondManagerTest.sol
+++ b/LUSDChickenBonds/src/test/TestContracts/ChickenBondManagerTest.sol
@@ -1742,6 +1742,8 @@ contract ChickenBondManagerTest is BaseTest {
         assertEqDecimal(accrualParameter, INITIAL_ACCRUAL_PARAMETER, 18);
     }
 
+    event AccrualParameterUpdated(uint256);
+
     function testControllerDoesAdjustWhenAgeOfSingleBondIsAboveTarget(uint256 _interval) public {
         uint256 interval = coerce(
             _interval,
@@ -1751,6 +1753,9 @@ contract ChickenBondManagerTest is BaseTest {
 
         uint256 bondID = createBondForUser(A, 100e18);
         vm.warp(block.timestamp + interval);
+
+        vm.expectEmit(false, false, false, false);
+        emit AccrualParameterUpdated(0x1337); // param doesn't matter since we're not checking data
         chickenInForUser(A, bondID);
 
         uint256 accrualParameter = chickenBondManager.accrualParameter();


### PR DESCRIPTION
This will enable us to reconstruct accrued bLUSD amounts in analytics queries, e.g. for pending bonds or chickened-out bonds.