### PR TITLE
test: Yearn deprecated the first strategy, so it reverts now

### DIFF
--- a/LUSDChickenBonds/src/test/ChickenBondManagerMainnetOnlyTest.t.sol
+++ b/LUSDChickenBonds/src/test/ChickenBondManagerMainnetOnlyTest.t.sol
@@ -45,7 +45,7 @@ contract ChickenBondManagerMainnetOnlyTest is BaseTest, MainnetTestSetup {
         _generateCurveRevenue();
 
         // harvest from both strategies in the vault
-        for (uint256 i = 0; i < 2; i++) {
+        for (uint256 i = 1; i < 2; i++) {
             // get strategy
             address strategy = yearnCurveVault.withdrawalQueue(i);
             // get keeper


### PR DESCRIPTION
I’m keeping the loop, even if it’s kind of dumb now (only 1 iteration), but this way we can adjust again easily if they do more changes (e.g. adding new strategies).